### PR TITLE
Remove Dependabot auto-merge workflow and update actions in deployment workflow

### DIFF
--- a/.github/workflows/validate-pull-request.yml
+++ b/.github/workflows/validate-pull-request.yml
@@ -27,5 +27,5 @@ jobs:
       - name: Run lint
         run: npm run lint
 
-      - name: Run lint
+      - name: Run format check
         run: npm run format:check


### PR DESCRIPTION
Eliminate the Dependabot auto-merge workflow and rename the lint step to format check in the pull request validation workflow. Update checkout and setup actions to their latest versions.